### PR TITLE
github lodash issue- updated to 4.17.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"


### PR DESCRIPTION
Github sent a dependency alert that we needed to upgrade to lodash 4.17.19. I changed them all in package.json.lock. It was low severity so maybe we ask Lachlan if we should worry about it. Either way, prob need an npm install after git pull.